### PR TITLE
feat: add OAuth 2.0 authentication support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,17 @@ S3_SECRET_KEY=your-secret-key
 S3_REGION=us-east-1
 S3_USE_PATH_STYLE=false
 
-# MCPRouter Authentication
+# MCPRouter Authentication (for MCP endpoints)
 MCPROUTER_SERVER_URL=https://mcprouter.app
 MCPROUTER_SERVER_API_KEY=your-mcprouter-api-key
+
+# OAuth/OIDC Authentication (for REST API endpoints)
+# Base URL of the OAuth server (JWKS endpoint will be: {OAUTH_SERVER_URL}/.well-known/jwks.json)
+OAUTH_SERVER_URL=https://auth.example.com
+# Optional: Expected issuer claim in JWT (for validation)
+OAUTH_ISSUER=https://auth.example.com
+# Optional: Expected audience claim in JWT (for validation)
+OAUTH_AUDIENCE=invoice-management-api
 
 # Build Configuration (for docker-compose build)
 VERSION=dev

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -56,11 +56,11 @@ func main() {
 	)
 
 	// Enable authentication if configured (must be before routes)
-	if os.Getenv("MCPROUTER_SERVER_URL") != "" {
+	if os.Getenv("OAUTH_SERVER_URL") != "" || os.Getenv("MCPROUTER_SERVER_URL") != "" {
 		if err := apiServer.EnableAuthentication(); err != nil {
 			log.Printf("Warning: Failed to enable authentication: %v", err)
 		} else {
-			log.Println("Authentication enabled via MCPRouter")
+			log.Println("Authentication enabled")
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/rxtech-lab/invoice-management
 go 1.25.0
 
 require (
+	github.com/MicahParks/keyfunc/v3 v3.7.0
 	github.com/aws/aws-sdk-go-v2 v1.32.6
 	github.com/aws/aws-sdk-go-v2/config v1.28.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.47
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.71.0
 	github.com/gofiber/fiber/v2 v2.52.9
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/mark3labs/mcp-go v0.37.0
@@ -19,6 +21,7 @@ require (
 )
 
 require (
+	github.com/MicahParks/jwkset v0.11.0 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 // indirect
@@ -59,5 +62,6 @@ require (
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.7.0 h1:pdafUNyq+p3ZlvjJX1HWFP7MA3+cLpDtg69U3kITJGM=
+github.com/MicahParks/keyfunc/v3 v3.7.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
@@ -50,6 +54,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gofiber/fiber/v2 v2.52.9 h1:YjKl5DOiyP3j0mO61u3NTmK7or8GzzWzCFzkboyP5cw=
 github.com/gofiber/fiber/v2 v2.52.9/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -114,6 +120,8 @@ golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
 golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/api/middleware/oauth.go
+++ b/internal/api/middleware/oauth.go
@@ -1,0 +1,198 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/rxtech-lab/invoice-management/internal/utils"
+)
+
+// OAuthConfig holds configuration for OAuth authentication
+type OAuthConfig struct {
+	// JWKSEndpoint is the URL to fetch JWKS from (e.g., "https://auth.example.com/.well-known/jwks.json")
+	JWKSEndpoint string
+
+	// Issuer to validate (optional, if empty, issuer is not validated)
+	Issuer string
+
+	// Audience to validate (optional)
+	Audience string
+
+	// RefreshInterval for JWKS key refresh (default: 1 hour)
+	RefreshInterval time.Duration
+
+	// RefreshTimeout for JWKS fetch timeout (default: 10 seconds)
+	RefreshTimeout time.Duration
+}
+
+// OAuthAuthenticator handles JWT validation against JWKS endpoint
+type OAuthAuthenticator struct {
+	jwks   keyfunc.Keyfunc
+	config OAuthConfig
+}
+
+// NewOAuthAuthenticator creates a new OAuth authenticator
+func NewOAuthAuthenticator(config OAuthConfig) (*OAuthAuthenticator, error) {
+	// Set defaults
+	if config.RefreshInterval == 0 {
+		config.RefreshInterval = time.Hour
+	}
+	if config.RefreshTimeout == 0 {
+		config.RefreshTimeout = 10 * time.Second
+	}
+
+	// Create JWKS keyfunc with automatic refresh
+	ctx, cancel := context.WithTimeout(context.Background(), config.RefreshTimeout)
+	defer cancel()
+
+	k, err := keyfunc.NewDefaultCtx(ctx, []string{config.JWKSEndpoint})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWKS keyfunc: %w", err)
+	}
+
+	return &OAuthAuthenticator{
+		jwks:   k,
+		config: config,
+	}, nil
+}
+
+// ValidateToken validates a JWT token and returns the claims
+func (a *OAuthAuthenticator) ValidateToken(tokenString string) (jwt.MapClaims, error) {
+	// Parse and validate the token
+	token, err := jwt.Parse(tokenString, a.jwks.Keyfunc,
+		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512"}),
+		jwt.WithExpirationRequired(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("invalid token: %w", err)
+	}
+
+	if !token.Valid {
+		return nil, fmt.Errorf("token is not valid")
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("invalid token claims")
+	}
+
+	// Validate issuer if configured
+	if a.config.Issuer != "" {
+		iss, _ := claims.GetIssuer()
+		if iss != a.config.Issuer {
+			return nil, fmt.Errorf("invalid issuer: expected %s, got %s", a.config.Issuer, iss)
+		}
+	}
+
+	// Validate audience if configured
+	if a.config.Audience != "" {
+		aud, _ := claims.GetAudience()
+		found := false
+		for _, audValue := range aud {
+			if audValue == a.config.Audience {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("invalid audience")
+		}
+	}
+
+	return claims, nil
+}
+
+// ExtractUser extracts AuthenticatedUser from JWT claims
+func (a *OAuthAuthenticator) ExtractUser(claims jwt.MapClaims) *utils.AuthenticatedUser {
+	user := &utils.AuthenticatedUser{}
+
+	// Extract subject (user ID)
+	if sub, ok := claims["sub"].(string); ok {
+		user.Sub = sub
+	}
+
+	// Extract roles (common claim names: "roles", "role", "realm_access.roles")
+	user.Roles = extractStringSlice(claims, "roles")
+	if len(user.Roles) == 0 {
+		user.Roles = extractStringSlice(claims, "role")
+	}
+
+	// Extract scopes (common claim names: "scope", "scp")
+	if scope, ok := claims["scope"].(string); ok {
+		user.Scopes = strings.Split(scope, " ")
+	} else {
+		user.Scopes = extractStringSlice(claims, "scp")
+	}
+
+	return user
+}
+
+// Close is a no-op for cleanup compatibility
+// keyfunc v3 handles lifecycle automatically with internal goroutines
+func (a *OAuthAuthenticator) Close() {
+	// No explicit cleanup needed in keyfunc v3
+}
+
+// extractStringSlice extracts a string slice from claims
+func extractStringSlice(claims jwt.MapClaims, key string) []string {
+	if val, ok := claims[key]; ok {
+		switch v := val.(type) {
+		case []interface{}:
+			result := make([]string, 0, len(v))
+			for _, item := range v {
+				if str, ok := item.(string); ok {
+					result = append(result, str)
+				}
+			}
+			return result
+		case []string:
+			return v
+		}
+	}
+	return nil
+}
+
+// FiberOAuthMiddleware creates a Fiber middleware for OAuth JWT authentication
+func FiberOAuthMiddleware(authenticator *OAuthAuthenticator, onSuccess func(*fiber.Ctx, *utils.AuthenticatedUser) error) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		// Get Authorization header
+		authHeader := c.Get("Authorization")
+		if authHeader == "" {
+			return c.Next() // No auth header, let other middleware handle it
+		}
+
+		// Check for Bearer token
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			return c.Next() // Not a Bearer token, let other middleware handle it
+		}
+
+		tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+
+		// Validate token
+		claims, err := authenticator.ValidateToken(tokenString)
+		if err != nil {
+			log.Printf("OAuth token validation failed: %v", err)
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Invalid or expired token",
+			})
+		}
+
+		// Extract user from claims
+		user := authenticator.ExtractUser(claims)
+
+		// Call success callback
+		if onSuccess != nil {
+			if err := onSuccess(c, user); err != nil {
+				return err
+			}
+		}
+
+		return c.Next()
+	}
+}

--- a/internal/assets/openapi.yaml
+++ b/internal/assets/openapi.yaml
@@ -598,7 +598,35 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: JWT token for authentication
+      description: |
+        JWT Bearer token authentication.
+
+        Obtain a JWT token from your OAuth/OIDC provider and include it in the
+        Authorization header as: `Authorization: Bearer <token>`
+
+        The JWT must:
+        - Be signed with RS256, RS384, RS512, ES256, ES384, or ES512
+        - Have a valid `sub` (subject) claim identifying the user
+        - Not be expired
+
+        Optional claims:
+        - `roles` or `role`: User roles for authorization
+        - `scope` or `scp`: OAuth scopes
+
+    OAuth2:
+      type: oauth2
+      description: OAuth 2.0 authentication flow
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.example.com/authorize
+          tokenUrl: https://auth.example.com/token
+          scopes:
+            read:invoices: Read invoices
+            write:invoices: Create, update, delete invoices
+            read:categories: Read categories
+            write:categories: Create, update, delete categories
+            read:companies: Read companies
+            write:companies: Create, update, delete companies
 
   parameters:
     CategoryId:
@@ -1125,3 +1153,10 @@ components:
 
 security:
   - BearerAuth: []
+  - OAuth2:
+      - read:invoices
+      - write:invoices
+      - read:categories
+      - write:categories
+      - read:companies
+      - write:companies


### PR DESCRIPTION
- Updated `.env.example` to include new OAuth configuration variables.
- Enhanced the API server to support both MCPRouter and OAuth authentication methods.
- Introduced a new `OAuthAuthenticator` for validating JWT tokens against a JWKS endpoint.
- Updated the OpenAPI documentation to reflect the new authentication flow and required claims.
- Refactored authentication middleware to prioritize OAuth over MCPRouter when both are configured.